### PR TITLE
Added BS hide classes to make tables display better on small devices

### DIFF
--- a/umibukela/templates/partners.html
+++ b/umibukela/templates/partners.html
@@ -26,33 +26,31 @@
   <!-- partners-table -->
   <div class="partners-table">
     <div class="container">
-      <div class="table-responsive">
-        <table class="table table-striped sortable">
-          <thead>
-            <tr>
-              <th data-sort="string" class="sorttable_sorted">Partner name</th>
-              <th data-sort="string">Latest Cycle Results</th>
-              <th data-sort="string">Sector</th>
-              <th data-sort="string">Province</th>
-            </tr>
-          </thead>
-  {% for partner in partners %}
+      <table class="table table-striped sortable">
+        <thead>
           <tr>
-            <td><a href="{% url 'partner' partner.slug %}">{{ partner.short_name }}</a></td>
-            <td>
-              {% if partner.latest_complete_result %}
-              <a href="{% url 'site-result' site_slug=partner.latest_complete_result.site.slug result_id=partner.latest_complete_result.id %}">
-                {{ partner.latest_complete_result.cycle.start_date|date:'j F Y' }}
-                - {{ partner.latest_complete_result.cycle.end_date|date:'j F Y' }}
-              </a>
-              {% endif %}
-            </td>
-            <td>{{ partner.latest_complete_result.site.sector.name }}</td>
-            <td>{{ partner.latest_complete_result.site.province.name }}</td>
+            <th data-sort="string" class="sorttable_sorted">Partner name</th>
+            <th data-sort="string" class="hidden-xs">Latest Cycle Results</th>
+            <th data-sort="string" class="hidden-xs hidden-sm">Sector</th>
+            <th data-sort="string" class="hidden-xs hidden-sm">Province</th>
           </tr>
-  {% endfor %}
-        </table>
-      </div>
+        </thead>
+{% for partner in partners %}
+        <tr>
+          <td><a href="{% url 'partner' partner.slug %}">{{ partner.short_name }}</a></td>
+          <td class="hidden-xs">
+            {% if partner.latest_complete_result %}
+            <a href="{% url 'site-result' site_slug=partner.latest_complete_result.site.slug result_id=partner.latest_complete_result.id %}">
+              {{ partner.latest_complete_result.cycle.start_date|date:'j F Y' }}
+              - {{ partner.latest_complete_result.cycle.end_date|date:'j F Y' }}
+            </a>
+            {% endif %}
+          </td>
+          <td class="hidden-xs hidden-sm">{{ partner.latest_complete_result.site.sector.name }}</td>
+          <td class="hidden-xs hidden-sm">{{ partner.latest_complete_result.site.province.name }}</td>
+        </tr>
+{% endfor %}
+      </table>
     </div>
   </div>
 </div>

--- a/umibukela/templates/sites.html
+++ b/umibukela/templates/sites.html
@@ -25,33 +25,31 @@
   <!-- sites-table -->
   <div class="sites-table page-section">
     <div class="container">
-      <div class="table-responsive">
-        <table class="table table-striped sortable">
-          <thead>
-            <tr>
-              <th data-sort="string" class="sorttable_sorted">Site name</th>
-              <th data-sort="string">Latest Cycle Results</th>
-              <th data-sort="string">Sector</th>
-              <th data-sort="string">Province</th>
-            </tr>
-          </thead>
-{% for site in sites %}
+      <table class="table table-striped sortable">
+        <thead>
           <tr>
-            <td><a href="{% url 'site' site_slug=site.slug %}">{{ site.name }}</a></td>
-            <td>
-              {% if site.latest_complete_result %}
-              <a href="{% url 'site-result' site_slug=site.slug result_id=site.latest_complete_result.id %}">
-                {{ site.latest_complete_result.cycle.start_date|date:'j F Y' }}
-                - {{ site.latest_complete_result.cycle.end_date|date:'j F Y' }}
-              </a>
-              {% endif %}
-            </td>
-            <td>{{ site.sector.name }}</td>
-            <td>{{ site.province.name }}</td>
+            <th data-sort="string" class="sorttable_sorted">Site name</th>
+            <th data-sort="string" class="hidden-xs">Latest Cycle Results</th>
+            <th data-sort="string" class="hidden-xs hidden-sm">Sector</th>
+            <th data-sort="string" class="hidden-xs hidden-sm">Province</th>
           </tr>
+        </thead>
+{% for site in sites %}
+        <tr>
+          <td><a href="{% url 'site' site_slug=site.slug %}">{{ site.name }}</a></td>
+          <td class="hidden-xs">
+            {% if site.latest_complete_result %}
+            <a href="{% url 'site-result' site_slug=site.slug result_id=site.latest_complete_result.id %}">
+              {{ site.latest_complete_result.cycle.start_date|date:'j F Y' }}
+              - {{ site.latest_complete_result.cycle.end_date|date:'j F Y' }}
+            </a>
+            {% endif %}
+          </td>
+          <td class="hidden-xs hidden-sm">{{ site.sector.name }}</td>
+          <td class="hidden-xs hidden-sm">{{ site.province.name }}</td>
+        </tr>
 {% endfor %}
-        </table>
-      </div>
+      </table>
     </div>
   </div>
   <!-- /sites-table -->


### PR DESCRIPTION
On mobile devices (XS): only the first column is now visible on the
Sites and Partners pages
On other small devices (SM): only the first two columns are now visibile
on the Sites and Partners pages
