### PR TITLE
use fake file size for missing files in dev when viewing results

### DIFF
--- a/umibukela/dev_storage.py
+++ b/umibukela/dev_storage.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+
+
+class DevFileSystemStorage(FileSystemStorage):
+    def size(self, name):
+        if settings.FAKE_MISSING_FILE_SIZE:
+            try:
+                return super(DevFileSystemStorage, self).size(name)
+            except OSError:
+                return 1337
+        else:
+            return super(DevFileSystemStorage, self).size(name)

--- a/umibukela/settings.py
+++ b/umibukela/settings.py
@@ -132,6 +132,8 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
 # file uploads
 if DEBUG:
+    DEFAULT_FILE_STORAGE = 'umibukela.dev_storage.DevFileSystemStorage'
+    FAKE_MISSING_FILE_SIZE = True
     MEDIA_URL = "/images/"
     MEDIA_ROOT = "/tmp/umibukela/images"
 else:


### PR DESCRIPTION
because temporarily hacking code for development will lead to breakage