### PR TITLE
Hide links to local govt which isn't used for new surveys

### DIFF
--- a/umibukela/templates/survey_type_detail.html
+++ b/umibukela/templates/survey_type_detail.html
@@ -28,7 +28,7 @@
 
   <div class="sites-table page-section">
     <div class="container">
-          
+
       <div class="monitoring-period">
 
         <div class="row description">
@@ -94,9 +94,10 @@
             </div>
 
             <!-- downloadable resources -->
+            {% if "local-government" not in survey_type.slug %}
             <p><a href="{% url 'national-summary-pdf' survey_type_slug=survey_type.slug cycle_id=latest_cycle.id %}"><i class="fa fa-download" aria-hidden="true"></i> Summary</a> &nbsp;&nbsp;
             <a href="{% url 'national-poster-pdf' survey_type_slug=survey_type.slug cycle_id=latest_cycle.id %}"><i class="fa fa-download" aria-hidden="true"></i> Poster</a></p>
-
+            {% endif %}
           </div>
         </section>
 
@@ -106,11 +107,13 @@
           <div class="province-title">
             <div class="container">
               <h3 id="{{ province.cycle_result_set__site__province__slug }}">{{ province.cycle_result_set__site__province__name }}
+                {% if "local-government" not in survey_type.slug %}
                 <small>
                   <a href="{% url 'province-summary-pdf' survey_type_slug=survey_type.slug province_slug=province.cycle_result_set__site__province__slug cycle_id=latest_cycle.id %}">Summary</a>
                    |
                    <a href="{% url 'province-poster-pdf' survey_type_slug=survey_type.slug province_slug=province.cycle_result_set__site__province__slug cycle_id=latest_cycle.id %}">Poster</a>
                 </small>
+                {% endif %}
               </h3>
             </div>
           </div>


### PR DESCRIPTION
There are a couple of surveys but aggregated data isn't really important for them
so not worth fixing the template and data for the summary view yet